### PR TITLE
Slightly improved U.S. English translation

### DIFF
--- a/src/main/resources/assets/ping/lang/en_us.json
+++ b/src/main/resources/assets/ping/lang/en_us.json
@@ -3,7 +3,7 @@
   "ping:key.categories.ping": "Ping",
 
   "_comment": "Pings",
-  "key.ping": "Opens Ping menu",
+  "key.ping": "Open Ping menu",
   "ping.key.alert": "Ping (Alert)",
   "ping.key.mine": "Ping (Mine)",
   "ping.key.look": "Ping (Look)",


### PR DESCRIPTION
This time I changed only "Opens Ping menu" to "Open Ping menu" to be consistent with vanilla Minecraft keybinding descriptions, which all use imperative mood (exceptions are: "hotbar slot" and "advancements"), and "Ping bloops" to "Ping bloop", since the ping sound is single.

And similarly as in #10, if you still don't agree with these changes, feel free to close this PR, and I will focus on Polish translation instead :D